### PR TITLE
Add tests reporter to default branch

### DIFF
--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,21 @@
+name: 'Test Report'
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+  
+jobs:
+  report:
+    name: Reports processing
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone the repository
+      uses: actions/checkout@v2
+    - name: .NET Tests Results
+      uses: dorny/test-reporter@v1
+      with:
+        artifact: test-results
+        name: .NET Tests results           
+        path: '**/**/*.trx'    
+        reporter: dotnet-trx


### PR DESCRIPTION
This workflow will be triggered only by completed run of "CI" workflow, which exist only in NetStandard branch, so it won't interfere with older code.

It needs to be placed in default branch, since only on default branch workflow_run triggers are working (GitHub limitation)