### PR TITLE
Prevent crash when USDValidPriceList is empty.

### DIFF
--- a/OnixData.Standard/Version3/OnixProduct.cs
+++ b/OnixData.Standard/Version3/OnixProduct.cs
@@ -646,7 +646,7 @@ namespace OnixData.Version3
 
                 if ((USDPrice == null) || (USDPrice.PriceAmountNum <= 0))
                 {
-                    if ((USDValidPriceList != null) || (USDValidPriceList.Count > 0))
+                    if ((USDValidPriceList != null) && (USDValidPriceList.Count > 0))
                         USDPrice = USDValidPriceList.ElementAt(0);
                 }
 

--- a/OnixData/Version3/OnixProduct.cs
+++ b/OnixData/Version3/OnixProduct.cs
@@ -646,7 +646,7 @@ namespace OnixData.Version3
 
                 if ((USDPrice == null) || (USDPrice.PriceAmountNum <= 0))
                 {
-                    if ((USDValidPriceList != null) || (USDValidPriceList.Count > 0))
+                    if ((USDValidPriceList != null) && (USDValidPriceList.Count > 0))
                         USDPrice = USDValidPriceList.ElementAt(0);
                 }
 


### PR DESCRIPTION
I discovered this while trying to read an ONIX file, and then dumping the individual products to JSON (for debugging).

Forgive me if this has bugs; I haven't had a chance to run this locally, as I did this in the Github hosted editor.