### PR TITLE
Unignore other text fields in legacy parser.

### DIFF
--- a/OnixData.Standard/Legacy/OnixLegacyOtherText.cs
+++ b/OnixData.Standard/Legacy/OnixLegacyOtherText.cs
@@ -16,7 +16,7 @@ namespace OnixData.Legacy
         public const int CONST_OTEXT_TYPE_ANNOTATION  = 2;
         public const int CONST_OTEXT_TYPE_REV_QUOTE   = 8;
         public const int CONST_OTEXT_TYPE_SERIES_DESC = 43;
-        
+
         #endregion
 
         public OnixLegacyOtherText()
@@ -58,7 +58,6 @@ namespace OnixData.Legacy
         }
 
         /// <remarks/>
-        [System.Xml.Serialization.XmlIgnore]
         public string Text
         {
             get
@@ -89,7 +88,6 @@ namespace OnixData.Legacy
         }
 
         /// <remarks/>
-        [System.Xml.Serialization.XmlIgnore]
         public string d104
         {
             get { return Text; }

--- a/OnixData/Legacy/OnixLegacyOtherText.cs
+++ b/OnixData/Legacy/OnixLegacyOtherText.cs
@@ -16,7 +16,7 @@ namespace OnixData.Legacy
         public const int CONST_OTEXT_TYPE_ANNOTATION  = 2;
         public const int CONST_OTEXT_TYPE_REV_QUOTE   = 8;
         public const int CONST_OTEXT_TYPE_SERIES_DESC = 43;
-        
+
         #endregion
 
         public OnixLegacyOtherText()
@@ -58,7 +58,6 @@ namespace OnixData.Legacy
         }
 
         /// <remarks/>
-        [System.Xml.Serialization.XmlIgnore]
         public string Text
         {
             get
@@ -89,7 +88,6 @@ namespace OnixData.Legacy
         }
 
         /// <remarks/>
-        [System.Xml.Serialization.XmlIgnore]
         public string d104
         {
             get { return Text; }


### PR DESCRIPTION
Other text text fields were previously ignored in the legacy parser, I'm assuming for memory benefits since the other text fields can get rather large, but in properly designed long running code, I don't think that is as big of an issue as not having the other text at all.